### PR TITLE
Update dependabot path and exclude s2n-tls-sys

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,8 @@ updates:
   # restricted-MSRV, so don't do batch updates
   - package-ecosystem: "cargo"
     directories:
-      - "/bindings/rust"
+      - "/bindings/rust/standard"
+      - "/bindings/rust/extended/s2n-tls"
+      - "/bindings/rust/extended/s2n-tls-tokio"
     schedule:
       interval: "daily"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Updated the craft paths for `restricted-MSRV` and excluded s2n-tls-sys due to [dependabot error](https://github.com/aws/s2n-tls/actions/runs/12514064399/job/34909604483).

### Call-outs:

N/A

### Testing:

testing on my local repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
